### PR TITLE
Update Docker base image to support latest kernels

### DIFF
--- a/hbase-1.1.2/Dockerfile
+++ b/hbase-1.1.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6.9
+FROM centos:latest
 MAINTAINER Nicola Ferraro <nibbio84@gmail.com>
 
 RUN yum install -y java-1.8.0-openjdk


### PR DESCRIPTION
CentOS 6 no longer work with the latest kernel, the container fail to start.